### PR TITLE
VIS-1104: check base image url and handle user input backslashes in labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipPictographs
 Type: Package
 Title: Pictograph htmlwidgets
-Version: 1.1.11
+Version: 1.1.12
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Wrappers for the rhtmlPictographs package, using the flip project conventions.

--- a/R/getwidthheightratio.R
+++ b/R/getwidthheightratio.R
@@ -6,19 +6,8 @@
 getWidthHeightRatio <- function(image.url)
 {
    # Download custom image to compute width-height ratio
-    response <- try(GET(image.url), silent = TRUE)
-    if (inherits(response, "try-error"))
-        stop("Could not retrieve image from '", image.url, "'. Check that url is correct.")
-    if(response$status_code != 200)
-        stop("Error (status code ", response$status_code, ") retrieving image ", image.url)
+    response <- getImage(image.url)
     tmp.type <- response$headers$'content-type'
-    if (any(grepl("text/html", tmp.type, fixed = TRUE)))
-        stop("The url content type is 'text/html'. Ensure the image url is correct and not redirected.")
-    # Give warning because sometimes chrome can fix this, but will show as blank in IE
-    unknown.type <- !any(grepl("image", tmp.type, fixed = TRUE))
-    if (unknown.type)
-        warning("URL content type is '", tmp.type,
-        "'. This may not display properly in all browsers.")
 
     whratio <- NA
     if (grepl("svg", tmp.type))
@@ -77,4 +66,28 @@ getWidthHeightRatio <- function(image.url)
             warning("Could not determine width-height ratio from image. Defaulting to 1.\n")
     }
     return(whratio)
+}
+
+getImage <- function(image.url)
+{
+    response <- try(GET(image.url), silent = TRUE)
+    if (inherits(response, "try-error"))
+        stop("Could not retrieve image from '", image.url, "'. Check that url is correct.")
+    if(response$status_code != 200)
+        stop("Error (status code ", response$status_code, ") retrieving image ", image.url)
+    tmp.type <- response$headers$'content-type'
+    if (any(grepl("text/html", tmp.type, fixed = TRUE)))
+        stop("The url content type is 'text/html'. Ensure the image url is correct and not redirected.")
+    # Give warning because sometimes chrome can fix this, but will show as blank in IE
+    unknown.type <- !any(grepl("image", tmp.type, fixed = TRUE))
+    if (unknown.type)
+        warning("URL content type is '", tmp.type,
+                "'. This may not display properly in all browsers.")
+    response
+}
+
+checkImageUrl <- function(image.url)
+{
+    getImage(image.url)
+    invisible()
 }

--- a/R/iconswithtext.R
+++ b/R/iconswithtext.R
@@ -291,7 +291,7 @@ cleanPictographLabels <- function(x)
     x <- gsub("\\s", " ", x)
 
     # Escape backslashes in labels. Why do we need so many slashes?
-    # If a user inputs a single backslash (\) in a text control,
+    # Answer: If a user inputs a single backslash (\) in a text control,
     # this becomes the R string "\\". We need to replace this with "\\\\"
     # for the JSON string, which is done using the line below:
     x <- gsub("\\\\", "\\\\\\\\", x)

--- a/R/iconswithtext.R
+++ b/R/iconswithtext.R
@@ -290,12 +290,14 @@ cleanPictographLabels <- function(x)
     # Note these can be coded as \n or \r
     x <- gsub("\\s", " ", x)
 
-    # Escape backslashes in labels
-    x <- gsub("\\", "\\\\")
+    # Escape backslashes in labels. Why do we need so many slashes?
+    # If a user inputs a single backslash (\) in a text control,
+    # this becomes the R string "\\". We need to replace this with "\\\\"
+    # for the JSON string, which is done using the line below:
+    x <- gsub("\\\\", "\\\\\\\\", x)
 
     # These characters used to be shown as text but that is
     # probably not what the user wants to see
-    x <- gsub("<br>", "\\\\n", x)
     x <- gsub("&nbsp;", " ", x)
     x <- gsub('"', '\\"', x, fixed = TRUE)
     return(x)

--- a/R/iconswithtext.R
+++ b/R/iconswithtext.R
@@ -290,11 +290,8 @@ cleanPictographLabels <- function(x)
     # Note these can be coded as \n or \r
     x <- gsub("\\s", " ", x)
 
-    # Escape backslashes in labels. Why do we need so many slashes?
-    # Answer: If a user inputs a single backslash (\) in a text control,
-    # this becomes the R string "\\". We need to replace this with "\\\\"
-    # for the JSON string, which is done using the line below:
-    x <- gsub("\\\\", "\\\\\\\\", x)
+    # Escape backslashes in labels
+    x <- gsub("\\", "\\\\", x, fixed = TRUE)
 
     # These characters used to be shown as text but that is
     # probably not what the user wants to see

--- a/R/iconswithtext.R
+++ b/R/iconswithtext.R
@@ -171,7 +171,14 @@ iconsWithText <- function (x,
     {
         if (nchar(base.icon.color) > 0)
             base.icon.color <- paste(base.icon.color, ":", sep="")
-        base.image.url <- if (is.custom.url) base.image else imageURL[image]
+        base.image.url <- if (is.custom.url)
+        {
+            checkImageUrl(base.image)
+            base.image
+        }
+        else
+            imageURL[image]
+
         base.image.str <- if (nchar(base.image.url) == 0 && is.custom.url) ""
                           else paste(",\"baseImage\":\"", image.type, ":", base.icon.color, base.image.url, "\"", sep="")
     }
@@ -282,6 +289,9 @@ cleanPictographLabels <- function(x)
     # New line characters were causing errors in the JSON
     # Note these can be coded as \n or \r
     x <- gsub("\\s", " ", x)
+
+    # Escape backslashes in labels
+    x <- gsub("\\", "\\\\")
 
     # These characters used to be shown as text but that is
     # probably not what the user wants to see

--- a/R/pictographchart.R
+++ b/R/pictographchart.R
@@ -543,7 +543,16 @@ PictographChart <- function(x,
         label.data.align.horizontal <- "right"
 
     image.url <- if (is.custom.url) image else imageURL[image]
-    base.image <- if (hide.base.image) NA else if (is.custom.url) base.image else imageURL[image]
+    base.image <- if (hide.base.image)
+        NA
+    else if (is.custom.url)
+    {
+        checkImageUrl(base.image)
+        base.image
+    }
+    else
+        imageURL[image]
+
     fill.icon.color <- if (is.custom.url) "" else c.hex
     width.height.ratio <- if (is.custom.url) getWidthHeightRatio(image) else imageWHRatio[image]
 

--- a/R/singlepicto.R
+++ b/R/singlepicto.R
@@ -211,7 +211,13 @@ SinglePicto <- function (x,
     {
         if (nchar(base.icon.color) > 0)
             base.icon.color <- paste(base.icon.color, ":", sep="")
-        base.image.url <- if (is.custom.url) base.image else imageURL[image]
+        base.image.url <- if (is.custom.url)
+        {
+            checkImageUrl(base.image)
+            base.image
+        }
+        else
+            imageURL[image]
         base.image.str <- if (nchar(base.image.url) == 0 && is.custom.url) ""
                           else paste(",\"baseImage\":\"", image.type, ":", base.icon.color, base.image.url, "\"", sep="")
     }

--- a/tests/testthat/test-getwidthheightratio.R
+++ b/tests/testthat/test-getwidthheightratio.R
@@ -1,13 +1,18 @@
 context("getWidthHeightRatio")
 
-test_that("Check content header",
-{
-    expect_error(getWidthHeightRatio("https://wiki.q-researchsoftware.com/images/a/ab/Dizzy_drunk_color.png", NA))
-    expect_error(getWidthHeightRatio("https://wiki.q-researchsoftware.com/wiki/File:Dizzy_drunk_color.png"),
+test_that("getWidthHeightRatio", {
+    expect_equal(getWidthHeightRatio("https://wiki.q-researchsoftware.com/images/a/ab/Dizzy_drunk_color.png"), 0.529)
+})
+
+test_that("getImage", {
+    expect_error(getImage("https://wiki.q-researchsoftware.com/images/a/ab/Dizzy_drunk_color.png"), NA)
+    expect_error(getImage("https://wiki.q-researchsoftware.com/wiki/File:Dizzy_drunk_color.png"),
                  "The url content type is 'text/html'")
-    expect_error(getWidthHeightRatio("google.com"), "The url content type is 'text/html'")
-    expect_error(getWidthHeightRatio("www.google.com"))
+    expect_error(getImage("google.com"), "The url content type is 'text/html'")
+    expect_error(getImage("www.google.com"), "The url content type is 'text/html'")
+})
 
-
-
+test_that("checkImageUrl", {
+    expect_error(checkImageUrl("https://wiki.q-researchsoftware.com/images/a/ab/Dizzy_drunk_color.png"), NA)
+    expect_error(checkImageUrl("www.google.com"), "The url content type is 'text/html'")
 })


### PR DESCRIPTION
VIS-1104 was caused by user inputting a windows file path instead of a url to the base image url which is not checked in R before passing to the widget. We now check the base image url in R. I also made some changes to `cleanPictographLabels` to escape in input backslashes and removed an unused line (as far as I know).