### PR TITLE
DPI-2906 Package flipPictographs in nix

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {}, displayrUtils }:
+
+pkgs.rPackages.buildRPackage {
+  name = "flipPictographs";
+  version = displayrUtils.extractRVersion (builtins.readFile ./DESCRIPTION); 
+  src = ./.;
+  description = ''Wrappers for the rhtmlPictographs package, using the flip project conventions.'';
+  propagatedBuildInputs = with pkgs.rPackages; [ 
+    flipStatistics
+    bmp
+    rhtmlPictographs
+    flipTables
+    flipTransformations
+    png
+    jpeg
+    janitor
+    verbs
+    httr
+    flipChartBasics
+    flipU
+    plotly
+  ];
+}


### PR DESCRIPTION
As part of the R Server CI/CD uplift, this task is to package flipPictographs in Nix to make R server CI/CD more reliable and reproducible. To build it, see https://github.com/Displayr/NixR